### PR TITLE
Add functionality to parse modified CVEs

### DIFF
--- a/Crawling/main.py
+++ b/Crawling/main.py
@@ -2,10 +2,11 @@ import requests, json, time, os, pytz
 from pymongo import MongoClient
 from datetime import datetime, timedelta
 
+
 class NVD_CVE_Parser:
     def __init__(self, api_url):
         self.api_url = api_url
-        self.seoul_tz = pytz.timezone('Asia/Seoul')
+        self.seoul_tz = pytz.timezone("Asia/Seoul")
 
     def fetch_cve_data(self, start_index: int, results_per_page: int):
         url = f"{self.api_url}/?resultsPerPage={results_per_page}&startIndex={start_index}"
@@ -20,18 +21,17 @@ class NVD_CVE_Parser:
                 return True
 
         elif response.status_code == 403:
-                print("API 요청이 너무 빠릅니다. 잠시 후 다시 시도합니다.")
-                time.sleep(6)
+            print("API 요청이 너무 빠릅니다. 잠시 후 다시 시도합니다.")
+            time.sleep(6)
 
         else:
             print(f"API 요청에 실패했습니다. 상태 코드: {response.status_code}")
             return False
-            
 
     def save_cve_data(self, cve_data: list):
         for cve_item in cve_data:
             cve_id = cve_item["cve"]["id"]
-            print(f'{cve_id} 정보 저장.....')
+            print(f"{cve_id} 정보 저장.....")
 
             year = self.__year_division(cve_id)
             self.__create_directory(year)
@@ -39,19 +39,19 @@ class NVD_CVE_Parser:
             self.save_json(cve_item)
 
     def __year_division(self, cve_id: str):
-        return cve_id.split('-')[1]
+        return cve_id.split("-")[1]
 
     def __create_directory(self, year: str):
-        if not os.path.exists(f'./jsons/{year}'):
+        if not os.path.exists(f"./jsons/{year}"):
             os.makedirs(f"./jsons/{year}")
 
     def save_json(self, cve_item: dict):
         cve_id = cve_item["cve"]["id"]
         year = self.__year_division(cve_id)
 
-        file_path = f'./jsons/{year}'
+        file_path = f"./jsons/{year}"
 
-        with open(f'{file_path}/{cve_id}.json', 'w') as out_file:
+        with open(f"{file_path}/{cve_id}.json", "w") as out_file:
             json.dump(cve_item, out_file, indent=4)
 
     def fetch_modified_cve_data(self, days: int = 0):
@@ -60,8 +60,8 @@ class NVD_CVE_Parser:
         start_of_yesterday = now.replace(hour=0, minute=0, second=0, microsecond=0)
         end_of_yesterday = start_of_yesterday + timedelta(days=1)
 
-        start_date = start_of_yesterday.isoformat().replace('+', '%2B')
-        end_date = end_of_yesterday.isoformat().replace('+', '%2B')
+        start_date = start_of_yesterday.isoformat().replace("+", "%2B")
+        end_date = end_of_yesterday.isoformat().replace("+", "%2B")
 
         url = f"{self.api_url}?lastModStartDate={start_date}&lastModEndDate={end_date}"
 
@@ -75,7 +75,6 @@ class NVD_CVE_Parser:
         else:
             print(f"{days}일 전에 수정된 수정된 CVE 데이터를 불러왔습니다.")
 
-    
 
 if __name__ == "__main__":
     NVD_API_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0/"
@@ -89,7 +88,7 @@ if __name__ == "__main__":
     # while True:
     #     if isinstance(nvd.fetch_cve_data(start_index, results_per_page), bool):
     #         break
-            
+
     #     start_index += results_per_page
 
     # 어제 변경된 데이터 파싱하는 코드


### PR DESCRIPTION
This pull request adds a new feature to the NVD_CVE_Parser class that fetches and parses CVEs that were modified on the previous day.

- Addition of fetch_modified_cve_data method
- This method retrieves the start and end times of the previous day (in Seoul timezone).
- These times are formatted in the ISO-8601 format (including a URL encoded offset-from-UTC).
- The formatted times are included in the API request URL.
- Modified CVE data is fetched through the request.
 - The fetched CVE data is parsed and saved.