### PR TITLE
Added keyword search functionality to API endpoint

### DIFF
--- a/API/route.py
+++ b/API/route.py
@@ -1,6 +1,6 @@
 from flask import request, jsonify
 from flask_restx import Namespace, Resource
-
+from Crawling.parsing import NVD_CVE_Parser
 
 db_api = Namespace("api/db", description="Database 관련 API")
 protected_dbs = ["admin", "config", "local"]
@@ -118,3 +118,24 @@ class CveYearCount(Resource):
         )
 
         return {"count": cve_count}
+
+@cve_api.route("/<string:keyword>")
+class CveByPlatform(Resource):
+    @cve_api.doc(params={"keyword": "Search keyword", "page": "Page number"}, responses={200: "Success"})
+    def get(self, keyword):
+        page = int(request.args.get("page", 1))
+        nvd = NVD_CVE_Parser(api_url="https://services.nvd.nist.gov/rest/json/cves/2.0/")
+
+        results_per_page = 2000
+
+        result = nvd.fetch_cve_data_with_keyword(
+            (page - 1) * results_per_page,
+            results_per_page,
+            keyword=keyword,
+            exact_match=True
+        )
+
+        if not result:
+            result = "No more results"
+
+        return jsonify({"cve": result})


### PR DESCRIPTION
## Description
API 엔드포인트에 키워드 검색 기능을 추가합니다.
이제 사용자는 특정 키워드를 기반으로 CVE를 검색할 수 있으며, API의 유연성과 유용성이 향상됩니다.

## 주요 변경사항
- NVD의 API를 사용하여 키워드 기반 검색을 구현했습니다.
- API 엔드포인트에 keyword, page 파라미터를 추가했습니다.

## 테스트
1. 애플리케이션을 시작하고 API가 실행 중인지 확인합니다.
2. `keyword`에 원하는 키워드를 대입하여 /api/cve/`keyword`?page=1로 GET 요청을 수행합니다.
3. API가 예상대로 키워드와 일치하는 CVE를 반환하는지 확인합니다.

## 스크린샷
### 테스트 결과
<img width="1680" alt="image" src="https://github.com/bug-hunting-project/CVE-Scout/assets/65268306/a1e3751a-ca99-473a-af96-8c1168e61b9a">
<img width="808" alt="image" src="https://github.com/bug-hunting-project/CVE-Scout/assets/65268306/a0942a0c-cca4-4eef-a9fc-4c44f24824d9">