### PR TITLE
Add a feature to store Grype results in MongoDB

### DIFF
--- a/API/route/sbom.py
+++ b/API/route/sbom.py
@@ -4,7 +4,7 @@ from werkzeug.utils import secure_filename
 import os
 import uuid
 import subprocess
-import shutil
+from DB import Mongo_Handler
 
 upload_directory = "upload"
 
@@ -14,7 +14,7 @@ def sbom(mongo_client):
     file_upload = reqparse.RequestParser()
     file_upload.add_argument('file', location='files', type=FileStorage, required=True, help='The file to be uploaded')
 
-    @api.route('/sbom/upload', methods=['POST'])
+    @api.route('/upload', methods=['POST'])
     class SbomUploadFile(Resource):
         @staticmethod
         def ensure_upload_directory_exists():
@@ -49,7 +49,7 @@ def sbom(mongo_client):
     filename_parser = reqparse.RequestParser()
     filename_parser.add_argument('filename', type=str, required=True, help='Name of the SBOM file to be scanned')
     
-    @api.route('/sbom/scan', methods=['GET'])
+    @api.route('/scan', methods=['GET'])
     class SbomScan(Resource):
         @staticmethod
         def run_syft_grype(target_directory):
@@ -69,6 +69,17 @@ def sbom(mongo_client):
                 return {"result":"false", "error":"Not config file"}
             elif run_result == 3:
                 return {"result":"false", "error":"Not SBOM file"}
+            
+        @staticmethod
+        def save(target_directory):
+            mongo = Mongo_Handler(target_directory)
+            file = os.path.join(target_directory, "vuln_list.json")
+            
+            
+            collection_name = file.split("/")[1]
+            result = mongo.grype_save(collection_name, file)            
+            
+            return result
                 
         @api.doc(
             params={"filename": {"description": "SBOM File", "in": "query", "type": "string"}},
@@ -81,13 +92,14 @@ def sbom(mongo_client):
 
             # Check if the directory exists in the upload directory
             directory_path = os.path.join(upload_directory, random_dir_name)
-            print(directory_path)
             if not os.path.exists(directory_path) or not os.path.isdir(directory_path):
                 return {"error": f"Directory {random_dir_name} not found"}, 404
 
             result = SbomScan.run_result(
                 SbomScan.run_syft_grype(directory_path)
             )
+            
+            SbomScan.save(directory_path)
             
             return result, 200
 

--- a/DB/mongo_handler.py
+++ b/DB/mongo_handler.py
@@ -1,11 +1,12 @@
 import os
-import datetime
 import json
 import logging
 from pymongo import MongoClient
 from pymongo.errors import ServerSelectionTimeoutError
 from typing import Union, List, Dict
 from pymongo import MongoClient
+from datetime import datetime, timedelta
+
 
 # Constants
 MONGO_URL = "mongodb://localhost:27017"
@@ -38,7 +39,7 @@ class Mongo_Handler:
             os.makedirs("log/DB_LOG")
 
         # Create a file handler
-        handler = logging.FileHandler(f"log/DB_LOG/db_handler_{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}.log")
+        handler = logging.FileHandler(f"log/DB_LOG/db_handler_{datetime.now().strftime('%Y%m%d%H%M%S')}.log")
         handler.setLevel(logging.INFO)
 
         # Create a logging format
@@ -181,3 +182,24 @@ class Mongo_Handler:
     def delete(self, collection_name:str) -> None:
         if self._is_collection(collection_name):
             self.db[collection_name].drop()
+            
+    def grype_save(self, collection_name:str, grype_result_file_path:str) -> bool:
+        # grype 결과 파일 로드
+        with open(grype_result_file_path, 'r') as file:
+            data = json.load(file)
+
+        # 3일 후에 만료되도록 설정
+        expiry_date = datetime.utcnow() + timedelta(days=3)
+        data['expiry'] = expiry_date
+
+        # 데이터 저장
+        collection = self.db[collection_name]
+        collection.insert_one(data)
+
+        # 3일 후에 자동 삭제되도록 TTL 인덱스 생성
+        # 이 작업은 한 번만 수행해도 되므로, 컬렉션이 이 인덱스를 가지고 있지 않은 경우에만 실행
+        if 'expiry_1' not in collection.index_information():
+            collection.create_index([('expiry', 1)], expireAfterSeconds=259200)  # 3일 (3*24*60*60초)
+            
+        return True
+    


### PR DESCRIPTION
## Description
Grype's result file is stored in MongoDB, allowing easy data control upon user request.

- Implemented logic in the /sbom/scan feature of the API to save Grype's result file in MongoDB.
- It's saved by the grype_save method of the Mongo_Handler class, and with a TTL (Time To Live) setting, it's retained for 3 days.

## Testing
A collection, with a name matching the randomly generated directory name, should be created in MongoDB to store the results from Grype.

## Screenshots
Given the backend nature of these changes and their interaction with external tools, screenshots might not provide significant insights. Instead, focus on the output logs and any generated reports to validate successful operations.